### PR TITLE
execution: shutdown running tests if a signal received

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,6 +129,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio-signals"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "miow"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,6 +185,7 @@ name = "raclette"
 version = "0.1.0"
 dependencies = [
  "mio 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio-signals 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pico-args 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -270,6 +281,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum libc 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
 "checksum log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 "checksum mio 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8962c171f57fcfffa53f4df1bb15ec4c8cf26a7569459c9ceb62d94aab0d9584"
+"checksum mio-signals 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0e96f64fd50f8817af1c4ca6b301a92bfd1460f25614edae6322fec906440aee"
 "checksum miow 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "07b88fb9795d4d36d62a012dfbf49a8f5cf12751f36d31a9dbe66d528e58979e"
 "checksum nix 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "83450fe6a6142ddd95fb064b746083fc4ef1705fe81f64a64e1d4b39f54a1055"
 "checksum ntapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 
 [dependencies]
 mio = { version = "0.7", features = ["os-poll", "pipe"] }
+mio-signals = "0.1.2"
 nix = "0.18"
 num_cpus = "1.0"
 pico-args = "0.3"


### PR DESCRIPTION
This change makes the test driver listen for signals and kill
running processes if a signal received.

This is required to avoid leaving background tasks running if a
user (or CI) decides to cancel the test suite.

Fixes #2.