### PR TITLE
report: add JSON reporter

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -33,6 +33,9 @@ pub enum Format {
     Auto,
     /// Use the same format that libtest uses.
     LibTest,
+    /// Use the Cargo JSON format.
+    /// See https://github.com/dfinity-lab/raclette/issues/10 for pointers.
+    Json,
     /// Use the format specified on http://testanything.org.
     Tap,
 }
@@ -87,7 +90,11 @@ Options:
                            'auto' (default), 'always' or 'never'
 
   -f, --format FMT         Output the test report in the specified format,
-                           FMT can be 'auto' (default), 'libtest' or 'tap'
+                           FMT can be
+                             'auto'    (default)
+                             'libtest' (emulate the output produced by cargo test)
+                             'json'    (libtest JSON format)
+                             'tap'     (Test Anything Protocol, http://testanything.org)
 
   -j, --jobs NJOBS         Run at most NJOBS tests in parallel
 
@@ -110,6 +117,7 @@ fn parse_format(input: &str) -> Result<Format, String> {
     match input {
         "auto" => Ok(Format::Auto),
         "libtest" => Ok(Format::LibTest),
+        "json" => Ok(Format::Json),
         "tap" => Ok(Format::Tap),
         _ => Err(format!("unsupported FMT value: {}", input)),
     }

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -36,6 +36,12 @@ pub struct Task {
     options: Options,
 }
 
+impl Task {
+    pub fn name(&self) -> String {
+        self.full_name.join("::")
+    }
+}
+
 /// A task that has just been spawned and started executing.
 struct RunningTask {
     full_name: Vec<String>,
@@ -92,6 +98,7 @@ impl CompletedTask {
 
 pub trait Report {
     fn init(&mut self, plan: &[Task]);
+    fn start(&mut self, task_name: String);
     fn report(&mut self, result: CompletedTask);
     fn done(&mut self);
 }
@@ -336,6 +343,7 @@ pub fn execute(config: &Config, mut tasks: Vec<Task>, report: &mut dyn Report) {
         while observed_tasks.len() < jobs {
             match tasks.pop() {
                 Some(mut task) => {
+                    report.start(task.name());
                     if let Some(reason) = task.options.skip_reason.take() {
                         report.report(skip_task(task, reason));
                         continue;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,6 +147,7 @@ pub fn default_main(default_config: Config, tree: TestTree) {
     let writer = report::ColorWriter::new(config.color);
     let mut report: Box<dyn execution::Report> = match config.format {
         Format::Auto | Format::LibTest => Box::new(report::LibTestReport::new(writer)),
+        Format::Json => Box::new(report::JsonReport::new(writer)),
         Format::Tap => Box::new(report::TapReport::new(writer)),
     };
     let plan = execution::make_plan(&config, tree);


### PR DESCRIPTION
This change introduces new report format, JSON, that is mostly
compatible with libtest JSON output.

Fixes #10.