### PR TITLE
Enable raclette to be run without reading the CLI args by default

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -153,7 +153,7 @@ impl Config {
 
     // Parses arguments from whathever pico_arg::Arguments
     fn from_pico_args(args: pico_args::Arguments) -> Result<Self, ConfigParseError> {
-        let mut args = args.clone(); // this clone is here to enable the args.free() in line 182
+        let mut args = args;
 
         if args.contains(["-h", "--help"]) {
             return Err(ConfigParseError::HelpRequested);

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
 use pico_args::Error as ArgsError;
-use std::time::Duration;
+use std::{ffi::OsString, time::Duration};
 
 #[derive(PartialEq, Clone, Copy)]
 pub enum When {
@@ -138,7 +138,23 @@ fn convert_error(err: ArgsError, what: &str) -> ConfigParseError {
 impl Config {
     /// Parses configuration from command line flags.
     pub fn from_args() -> Result<Self, ConfigParseError> {
-        let mut args = pico_args::Arguments::from_env();
+        let args = pico_args::Arguments::from_env();
+        Config::from_pico_args(args)
+    }
+
+    /// Parses configuration from a vector of [OsString]s, note that the
+    /// executable name *must be removed*. This is usefull when calling raclette
+    /// from a custom main that wants to split options to raclette from
+    /// options to the test. Refer to [pico_args::Arguments::from_vec] for further docs.
+    pub fn from_vec(vargs: Vec<OsString>) -> Result<Self, ConfigParseError> {
+        let args = pico_args::Arguments::from_vec(vargs);
+        Config::from_pico_args(args)
+    }
+
+    // Parses arguments from whathever pico_arg::Arguments
+    fn from_pico_args(args: pico_args::Arguments) -> Result<Self, ConfigParseError> {
+        let mut args = args.clone(); // this clone is here to enable the args.free() in line 182
+
         if args.contains(["-h", "--help"]) {
             return Err(ConfigParseError::HelpRequested);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,8 +115,11 @@ pub fn should_panic(
     }
 }
 
+/// Runs raclette with a default config but reads the command line arguments
+/// and overrides settings from the default config. If this behavior is undesired
+/// refer to [default_main_no_config_override] instead.
 pub fn default_main(default_config: Config, tree: TestTree) {
-    use config::{ConfigParseError as E, Format};
+    use config::ConfigParseError as E;
 
     let override_config = Config::from_args().unwrap_or_else(|err| match err {
         E::HelpRequested => {
@@ -140,6 +143,12 @@ pub fn default_main(default_config: Config, tree: TestTree) {
     });
 
     let config = override_config.merge(default_config);
+    default_main_no_config_override(config, tree);
+}
+
+/// Runs raclette with a fixed configuration. Does not inspect command line options.
+pub fn default_main_no_config_override(config: Config, tree: TestTree) {
+    use config::Format;
 
     let writer = report::ColorWriter::new(config.color);
     let mut report: Box<dyn execution::Report> = match config.format {


### PR DESCRIPTION
Raclette would always try to parse the command line arguments in `default_main`. I split it in two main functions, one that tries to parse the CLI args and overrides a default config, which then calls a `default_main_no_override` that runs raclette with a fixed config. We will want to use the later in `dfinity/rs/tests`.