### PR TITLE
Returns execution::TaskResult from the main function

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -73,11 +73,7 @@ pub enum ConfigParseError {
     Unknown(String),
 }
 
-pub(crate) fn produce_help() -> String {
-    format!(
-        r#"Usage: {} [OPTIONS] [TESTNAME]
-
-Options:
+pub const HELP_STR: &str = r#"
       --skip FILTER        Skip tests whose names contain FILTER
                            (this flag can be used multiple times)
 
@@ -97,10 +93,19 @@ Options:
                              'tap'     (Test Anything Protocol, http://testanything.org)
 
   -j, --jobs NJOBS         Run at most NJOBS tests in parallel
+"#;
+
+pub(crate) fn produce_help() -> String {
+    format!(
+        r#"Usage: {} [OPTIONS] [TESTNAME]
+
+Options:
+{}
 
   -h, --help               Display this help and exit
 "#,
-        std::env::args().next().unwrap()
+        std::env::args().next().unwrap(),
+        HELP_STR
     )
 }
 

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -25,7 +25,10 @@ pub enum Status {
 }
 
 impl Status {
-    pub fn is_success_or_skip(&self) -> bool {
+    /// Returns whether a [Status] represents a non-failure. This includes
+    /// [Status::Success] and [Status::Skipped]. Anything else is a failure
+    /// of some sort.
+    pub fn is_ok(&self) -> bool {
         match self {
             Status::Success => true,
             Status::Skipped(_) => true,

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -497,7 +497,7 @@ pub fn execute(config: &Config, mut tasks: Vec<Task>, report: &mut dyn Report) -
 
             task_results.push(TaskResult {
                 full_name: observed_task.full_name.clone(),
-                duration: duration.clone(),
+                duration,
                 status: status.clone(),
             });
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,9 @@ pub fn should_panic(
 /// Runs raclette with a default config but reads the command line arguments
 /// and overrides settings from the default config. If this behavior is undesired
 /// refer to [default_main_no_config_override] instead.
-pub fn default_main(default_config: Config, tree: TestTree) {
+///
+/// Returns a list of [execution::TaskResult] for each test that was ran.
+pub fn default_main(default_config: Config, tree: TestTree) -> Vec<execution::TaskResult> {
     use config::ConfigParseError as E;
 
     let override_config = Config::from_args().unwrap_or_else(|err| match err {
@@ -143,11 +145,14 @@ pub fn default_main(default_config: Config, tree: TestTree) {
     });
 
     let config = override_config.merge(default_config);
-    default_main_no_config_override(config, tree);
+    default_main_no_config_override(config, tree)
 }
 
 /// Runs raclette with a fixed configuration. Does not inspect command line options.
-pub fn default_main_no_config_override(config: Config, tree: TestTree) {
+pub fn default_main_no_config_override(
+    config: Config,
+    tree: TestTree,
+) -> Vec<execution::TaskResult> {
     use config::Format;
 
     let writer = report::ColorWriter::new(config.color);
@@ -158,5 +163,5 @@ pub fn default_main_no_config_override(config: Config, tree: TestTree) {
     };
     let plan = execution::make_plan(&config, tree);
 
-    execution::execute(&config, plan, &mut *report);
+    execution::execute(&config, plan, &mut *report)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@ mod execution;
 mod report;
 
 pub use config::Config;
+pub use execution::CompletedTask;
+pub use execution::Status;
 
 use std::any::Any;
 use std::string::ToString;
@@ -120,7 +122,7 @@ pub fn should_panic(
 /// refer to [default_main_no_config_override] instead.
 ///
 /// Returns a list of [execution::TaskResult] for each test that was ran.
-pub fn default_main(default_config: Config, tree: TestTree) -> Vec<execution::TaskResult> {
+pub fn default_main(default_config: Config, tree: TestTree) -> Vec<execution::CompletedTask> {
     use config::ConfigParseError as E;
 
     let override_config = Config::from_args().unwrap_or_else(|err| match err {
@@ -152,7 +154,7 @@ pub fn default_main(default_config: Config, tree: TestTree) -> Vec<execution::Ta
 pub fn default_main_no_config_override(
     config: Config,
     tree: TestTree,
-) -> Vec<execution::TaskResult> {
+) -> Vec<execution::CompletedTask> {
     use config::Format;
 
     let writer = report::ColorWriter::new(config.color);

--- a/src/report.rs
+++ b/src/report.rs
@@ -118,7 +118,7 @@ impl Report for TapReport {
 
     fn start(&mut self, _name: String) {}
 
-    fn report(&mut self, task: CompletedTask) {
+    fn report(&mut self, task: &CompletedTask) {
         self.count += 1;
         let (ok, suffix) = match &task.status {
             Status::Success => (true, None),
@@ -227,7 +227,7 @@ impl Report for LibTestReport {
 
     fn start(&mut self, _name: String) {}
 
-    fn report(&mut self, task: CompletedTask) {
+    fn report(&mut self, task: &CompletedTask) {
         enum S {
             Ok,
             Ignored,
@@ -253,7 +253,7 @@ impl Report for LibTestReport {
                 self.ignored += 1;
             }
             S::Failed => {
-                self.failed.push(task);
+                self.failed.push(task.clone());
             }
         }
     }
@@ -389,7 +389,7 @@ impl Report for JsonReport {
         writeln!(self.writer).unwrap();
     }
 
-    fn report(&mut self, task: CompletedTask) {
+    fn report(&mut self, task: &CompletedTask) {
         self.stats.update(&task);
         match task.status {
             Status::Success => {

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -33,7 +33,10 @@ fn tests() -> TestTree {
                 "arithmetics",
                 vec![
                     test_case("addition", || assert_eq!(4, 2 + 2)),
-                    test_case("bad math", || assert_eq!(47, 7 * 7)),
+                    test_case(
+                        "bad math",
+                        should_panic("assertion failed", || assert_eq!(47, 7 * 7)),
+                    ),
                     test_case(
                         "div by zero",
                         should_panic("zero", || {
@@ -54,5 +57,15 @@ fn tests() -> TestTree {
 }
 
 fn main() {
-    default_main(Config::default(), tests());
+    let completed_tasks = default_main(Config::default(), tests());
+    let failed_tasks: Vec<CompletedTask> = completed_tasks
+        .into_iter()
+        .filter(|task| !task.status.is_success_or_skip())
+        .collect();
+
+    // In this particular test-suite, we expect two infinite loops to be stopped by raclette,
+    // in your case, you should probably ensure failed_tasks.len() == 0
+    if failed_tasks.len() != 2 {
+        std::process::exit(1);
+    }
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -54,5 +54,5 @@ fn tests() -> TestTree {
 }
 
 fn main() {
-    default_main(Config::default(), tests())
+    default_main(Config::default(), tests());
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -60,7 +60,7 @@ fn main() {
     let completed_tasks = default_main(Config::default(), tests());
     let failed_tasks: Vec<CompletedTask> = completed_tasks
         .into_iter()
-        .filter(|task| !task.status.is_success_or_skip())
+        .filter(|task| !task.status.is_ok())
         .collect();
 
     // In this particular test-suite, we expect two infinite loops to be stopped by raclette,


### PR DESCRIPTION
* create execution::CompletedTask, to be returned to raclette's caller
and further analyzed if necessary.

* Make the help string a public constant, so callers can incorporate it
in their CLI