### PR TITLE
Provide a StageReporter to tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,295 +4,370 @@
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
 name = "arrayvec"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "autocfg"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "base64"
-version = "0.11.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "bincode"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f30d3a39baa26f9651f17b375061f3233dde33424a8b72b0dbe93a68a0bc896d"
+dependencies = [
+ "byteorder",
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "blake2b_simd"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
 dependencies = [
- "arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
 ]
 
 [[package]]
-name = "cc"
-version = "1.0.61"
+name = "byteorder"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
+
+[[package]]
+name = "cc"
+version = "1.0.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
 
 [[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.7.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
 dependencies = [
- "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg",
+ "cfg-if 1.0.0",
+ "lazy_static",
 ]
 
 [[package]]
 name = "dirs"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "dirs-sys 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10",
+ "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_users 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
 dependencies = [
- "libc 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
 ]
 
 [[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.80"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
 
 [[package]]
 name = "log"
-version = "0.4.11"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
 name = "mio"
-version = "0.7.5"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e50ae3f04d169fcc9bde0b547d1c205219b7157e07ded9c5aff03e0637cb3ed7"
 dependencies = [
- "libc 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "miow 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "ntapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
+ "log",
+ "miow",
+ "ntapi",
+ "winapi",
 ]
 
 [[package]]
 name = "mio-signals"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb34b75b7d003cb3b124b3faac5e4f0c8de1d47e252a879aaaa084fc440ee4f"
 dependencies = [
- "libc 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
+ "log",
+ "mio",
 ]
 
 [[package]]
 name = "miow"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
- "socket2 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "socket2",
+ "winapi",
 ]
 
 [[package]]
 name = "nix"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83450fe6a6142ddd95fb064b746083fc4ef1705fe81f64a64e1d4b39f54a1055"
 dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.61 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags",
+ "cc",
+ "cfg-if 0.1.10",
+ "libc",
 ]
 
 [[package]]
 name = "ntapi"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
- "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi",
 ]
 
 [[package]]
 name = "num_cpus"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
- "hermit-abi 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
 name = "pico-args"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28b9b4df73455c861d7cbf8be42f01d3b373ed7f02e378d55fa84eafc6f638b1"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+dependencies = [
+ "unicode-xid",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
+dependencies = [
+ "proc-macro2",
+]
 
 [[package]]
 name = "raclette"
 version = "0.1.0"
 dependencies = [
- "mio 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio-signals 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "nix 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pico-args 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "term 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bincode",
+ "mio",
+ "mio-signals",
+ "nix",
+ "num_cpus",
+ "pico-args",
+ "serde",
+ "term",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.56"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_users"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
 dependencies = [
- "getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
- "rust-argon2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom",
+ "redox_syscall",
+ "rust-argon2",
 ]
 
 [[package]]
 name = "rust-argon2"
-version = "0.7.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
 dependencies = [
- "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "blake2b_simd 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64",
+ "blake2b_simd",
+ "constant_time_eq",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "socket2"
-version = "0.3.15"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 1.0.0",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
 name = "term"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0863a3345e70f61d613eab32ee046ccd1bcc5f9105fe402c61fcd0c13eeb8b5"
 dependencies = [
- "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dirs",
+ "winapi",
 ]
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 dependencies = [
- "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
 ]
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[metadata]
-"checksum arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
-"checksum arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
-"checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
-"checksum base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
-"checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-"checksum blake2b_simd 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
-"checksum cc 1.0.61 (registry+https://github.com/rust-lang/crates.io-index)" = "ed67cbde08356238e75fc4656be4749481eeffb09e19f320a25237d5221c985d"
-"checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-"checksum constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-"checksum crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
-"checksum dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
-"checksum dirs-sys 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
-"checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
-"checksum hermit-abi 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
-"checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-"checksum libc 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
-"checksum log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
-"checksum mio 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8962c171f57fcfffa53f4df1bb15ec4c8cf26a7569459c9ceb62d94aab0d9584"
-"checksum mio-signals 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0e96f64fd50f8817af1c4ca6b301a92bfd1460f25614edae6322fec906440aee"
-"checksum miow 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "07b88fb9795d4d36d62a012dfbf49a8f5cf12751f36d31a9dbe66d528e58979e"
-"checksum nix 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "83450fe6a6142ddd95fb064b746083fc4ef1705fe81f64a64e1d4b39f54a1055"
-"checksum ntapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
-"checksum num_cpus 1.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
-"checksum pico-args 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "28b9b4df73455c861d7cbf8be42f01d3b373ed7f02e378d55fa84eafc6f638b1"
-"checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
-"checksum redox_users 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "09b23093265f8d200fa7b4c2c76297f47e681c655f6f1285a8780d6a022f7431"
-"checksum rust-argon2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017"
-"checksum socket2 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "b1fa70dc5c8104ec096f4fe7ede7a221d35ae13dcd19ba1ad9a81d2cab9a1c44"
-"checksum term 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c0863a3345e70f61d613eab32ee046ccd1bcc5f9105fe402c61fcd0c13eeb8b5"
-"checksum wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)" = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-"checksum winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,3 @@ num_cpus = "1.0"
 pico-args = "0.3"
 term = "0.6"
 
-[[test]]
-name = "main"
-harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,12 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bincode = "1.3.1"
 mio = { version = "0.7", features = ["os-poll", "pipe"] }
 mio-signals = "0.1.2"
 nix = "0.18"
 num_cpus = "1.0"
 pico-args = "0.3"
+serde = { version = "1.0", features = ["derive"] }
 term = "0.6"
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -66,6 +66,7 @@ pub struct Config {
     pub(crate) nocapture: bool,
 }
 
+#[derive(Debug)]
 pub enum ConfigParseError {
     HelpRequested,
     OptionError(String),

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -137,7 +137,7 @@ pub trait Report {
     }
 }
 
-pub struct StageReportSender {
+pub struct TestContext {
     sender: pipe::Sender,
     // Since we define the stages to be linear, we just need to
     // keep one timestamp to report a stage's duration.
@@ -168,7 +168,7 @@ pub struct StageReport {
     duration: Duration,
 }
 
-impl StageReportSender {
+impl TestContext {
     pub fn report_stage_status<N: ToString>(&mut self, stage_name: N, status: StageStatus) {
         let stage_name = stage_name.to_string();
         let end = Instant::now();
@@ -330,7 +330,7 @@ fn launch(task: Task) -> RunningTask {
             unistd::close(stderr_fd).expect("child: failed to close stderr");
             unistd::dup2(stderr_sender.as_raw_fd(), stderr_fd).unwrap();
 
-            let mut stage_reporter = StageReportSender {
+            let mut stage_reporter = TestContext {
                 sender: report_sender,
                 started_at: Instant::now(),
             };

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -225,7 +225,7 @@ impl StreamDecoder {
             let res: StageReport =
                 bincode::deserialize(&payload).expect("failed to deserialize a bincode message");
             // Update the offset
-            self.offset = self.offset + size_of::<usize>() + payload_size;
+            self.offset = payload_offset + payload_size;
             Some(res)
         } else {
             None

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -220,8 +220,8 @@ impl StreamDecoder {
                 return None;
             }
 
-            let payload = &self.buf
-                [self.offset + size_of::<usize>()..self.offset + size_of::<usize>() + payload_size];
+            let payload_offset = self.offset + size_of::<usize>();
+            let payload = &self.buf[payload_offset .. payload_offset + payload_size];
             let res: StageReport =
                 bincode::deserialize(&payload).unwrap_or_else(|e| panic!(format!("{:?}", e)));
             // Update the offset

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -223,7 +223,7 @@ impl StreamDecoder {
             let payload_offset = self.offset + size_of::<usize>();
             let payload = &self.buf[payload_offset .. payload_offset + payload_size];
             let res: StageReport =
-                bincode::deserialize(&payload).unwrap_or_else(|e| panic!(format!("{:?}", e)));
+                bincode::deserialize(&payload).expect("failed to deserialize a bincode message");
             // Update the offset
             self.offset = self.offset + size_of::<usize>() + payload_size;
             Some(res)

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -603,7 +603,7 @@ pub fn execute(
                         if let Some(ref mut pipe) = observed_task.report_pipe {
                             let n = pipe.read(&mut buf).expect("failed to read REPORT");
                             observed_task.report_decoder.append(&buf[0..n]);
-                            if let Some(stage_rep) = observed_task.report_decoder.try_decode() {
+                            while let Some(stage_rep) = observed_task.report_decoder.try_decode() {
                                 report.stage(&observed_task.full_name, stage_rep);
                             }
                         }

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -173,7 +173,7 @@ impl StageReportSender {
         let stage_name = stage_name.to_string();
         let end = std::time::SystemTime::now();
         let start = self.started_at;
-        self.started_at = end.clone();
+        self.started_at = end;
 
         let payload = StageReport {
             stage_name,

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -213,7 +213,7 @@ impl StreamDecoder {
     fn try_decode(&mut self) -> Option<StageReport> {
         let avail = self.buf.len() - self.offset;
 
-        if avail <= size_of::<usize>() {
+        if avail < size_of::<usize>() {
             return None;
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,14 +5,14 @@ mod report;
 pub use config::Config;
 pub use execution::CompletedTask;
 pub use execution::StageReport;
-pub use execution::StageReportSender;
 pub use execution::StageStatus;
 pub use execution::Status;
+pub use execution::TestContext;
 
 use std::any::Any;
 use std::string::ToString;
 
-type GenericAssertion = Box<dyn FnOnce(&mut StageReportSender) + 'static>;
+type GenericAssertion = Box<dyn FnOnce(&mut TestContext) + 'static>;
 
 pub struct TestTree(TreeNode);
 
@@ -61,7 +61,7 @@ pub fn test_case<N: ToString, A: FnOnce() + 'static>(name: N, assertion: A) -> T
     test_case_reporter(name, |_| assertion())
 }
 
-pub fn test_case_reporter<N: ToString, A: FnOnce(&mut StageReportSender) + 'static>(
+pub fn test_case_reporter<N: ToString, A: FnOnce(&mut TestContext) + 'static>(
     name: N,
     assertion: A,
 ) -> TestTree {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ fn try_get_panic_msg<'a>(obj: &'a Box<dyn Any + Send + 'static>) -> Option<&'a s
 }
 
 pub fn test_case<N: ToString, A: FnOnce() + 'static>(name: N, assertion: A) -> TestTree {
-    test_case_reporter(name, |_| assertion())
+    test_case_ctx(name, |_| assertion())
 }
 
 pub fn test_case_ctx<N: ToString, A: FnOnce(&mut TestContext) + 'static>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ pub fn test_case<N: ToString, A: FnOnce() + 'static>(name: N, assertion: A) -> T
     test_case_reporter(name, |_| assertion())
 }
 
-pub fn test_case_reporter<N: ToString, A: FnOnce(&mut TestContext) + 'static>(
+pub fn test_case_ctx<N: ToString, A: FnOnce(&mut TestContext) + 'static>(
     name: N,
     assertion: A,
 ) -> TestTree {

--- a/tests/raclette_sample_main.rs
+++ b/tests/raclette_sample_main.rs
@@ -56,16 +56,29 @@ fn tests() -> TestTree {
     )
 }
 
-fn main() {
-    let completed_tasks = default_main(Config::default(), tests());
+// The test suite above is engineered to have two timeouts and one
+// skipped test.
+const NUM_FAILURES: usize = 2;
+const NUM_IGNORED: usize = 1;
+
+#[test]
+fn raclette_sample_main() {
+    let completed_tasks = default_main(Config::default().format(config::Format::Json), tests());
     let failed_tasks: Vec<CompletedTask> = completed_tasks
         .into_iter()
         .filter(|task| !task.status.is_ok())
         .collect();
 
+    println!(
+        r#"This executable runs a raclette test suite which has been engineered
+to have {} failures and {} ignored test. If raclette detected these
+failures and ignored tests correctly this process returns 0"#,
+        NUM_FAILURES, NUM_IGNORED,
+    );
+
     // In this particular test-suite, we expect two infinite loops to be stopped by raclette,
     // in your case, you should probably ensure failed_tasks.len() == 0
-    if failed_tasks.len() != 2 {
+    if failed_tasks.len() != NUM_FAILURES {
         std::process::exit(1);
     }
 }

--- a/tests/raclette_sample_main.rs
+++ b/tests/raclette_sample_main.rs
@@ -26,10 +26,9 @@ fn loop_infinitely() {
 }
 
 fn test_my_reporter(rep: &mut StageReportSender) {
-    rep.report_stage_start("first");
     println!("Sleeping one second");
     std::thread::sleep(Duration::from_millis(1234));
-    rep.report_stage_end("first", StageStatus::Success);
+    rep.report_stage_status("first", StageStatus::Success);
 }
 
 fn tests() -> TestTree {

--- a/tests/raclette_sample_main.rs
+++ b/tests/raclette_sample_main.rs
@@ -58,7 +58,7 @@ fn tests() -> TestTree {
                 "two infinite loops are enough",
                 test_case("infinite loop 3", loop_infinitely),
             ),
-            test_case_reporter("with a reporter", test_my_reporter),
+            test_case_ctx("with a reporter", test_my_reporter),
         ],
     )
 }

--- a/tests/raclette_sample_main.rs
+++ b/tests/raclette_sample_main.rs
@@ -25,6 +25,13 @@ fn loop_infinitely() {
     }
 }
 
+fn test_my_reporter(rep: &mut StageReportSender) {
+    rep.report_stage_start("first");
+    println!("Sleeping one second");
+    std::thread::sleep(Duration::from_millis(1234));
+    rep.report_stage_end("first", StageStatus::Success);
+}
+
 fn tests() -> TestTree {
     test_suite(
         "all",
@@ -52,6 +59,7 @@ fn tests() -> TestTree {
                 "two infinite loops are enough",
                 test_case("infinite loop 3", loop_infinitely),
             ),
+            test_case_reporter("with a reporter", test_my_reporter),
         ],
     )
 }

--- a/tests/raclette_sample_main.rs
+++ b/tests/raclette_sample_main.rs
@@ -25,7 +25,7 @@ fn loop_infinitely() {
     }
 }
 
-fn test_my_reporter(rep: &mut StageReportSender) {
+fn test_my_reporter(rep: &mut TestContext) {
     println!("Sleeping one second");
     std::thread::sleep(Duration::from_millis(1234));
     rep.report_stage_status("first", StageStatus::Success);


### PR DESCRIPTION
If the users of `raclette` decide to split their tests in multiple smaller parts, they might want to be able to report the result of these individual parts. This PR adds some functionality in that regard.