### PR TITLE
lib: make default_main exit(1) on test failures

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -13,4 +13,4 @@ jobs:
       - name: Build
         uses: icepuma/rust-action@1.45.2
         with:
-          args: cargo fmt -- --check && cargo clippy -- -Dwarnings && cargo build --tests
+          args: cargo fmt -- --check && cargo clippy -- -Dwarnings && cargo build --tests --examples

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@ pico-args = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 term = "0.6"
 
+[[example]]
+name = "raclette_main"
+

--- a/examples/raclette_main.rs
+++ b/examples/raclette_main.rs
@@ -63,29 +63,6 @@ fn tests() -> TestTree {
     )
 }
 
-// The test suite above is engineered to have two timeouts and one
-// skipped test.
-const NUM_FAILURES: usize = 2;
-const NUM_IGNORED: usize = 1;
-
-#[test]
-fn raclette_sample_main() {
-    let completed_tasks = default_main(Config::default().format(config::Format::Json), tests());
-    let failed_tasks: Vec<CompletedTask> = completed_tasks
-        .into_iter()
-        .filter(|task| !task.status.is_ok())
-        .collect();
-
-    println!(
-        r#"This executable runs a raclette test suite which has been engineered
-to have {} failures and {} ignored test. If raclette detected these
-failures and ignored tests correctly this process returns 0"#,
-        NUM_FAILURES, NUM_IGNORED,
-    );
-
-    // In this particular test-suite, we expect two infinite loops to be stopped by raclette,
-    // in your case, you should probably ensure failed_tasks.len() == 0
-    if failed_tasks.len() != NUM_FAILURES {
-        std::process::exit(1);
-    }
+fn main() {
+    default_main(Config::default().format(config::Format::Json), tests());
 }


### PR DESCRIPTION
This change makes sure default_main exits with a non-zero status if
any of the tests failed. There is, however, a way to override this
behaviour.

This is a BREAKING CHANGE, but there is a simple migration path to get
the old behavior back:

    - let completed_tasks = default_main(...);
    + let completed_tasks = default_main(...).into_completed_tasks();